### PR TITLE
[hpc] Remeber which NIC received DHCP

### DIFF
--- a/src/config/hpc/hpc.ipxe
+++ b/src/config/hpc/hpc.ipxe
@@ -21,6 +21,7 @@ ifclose
 set vidx:int8 0
 :dhcpcheck isset ${net${vidx}/mac} || goto configured
   ifopen net${vidx} || echo Failed to open net${vidx}
+  set boot-nic net${vidx} # constantly set this, once DHCP works this'll refer to the right NIC.
   ifconf -c dhcp --timeout 20000 net${vidx} && goto configured || ifclose net${vidx}
   inc vidx && goto dhcpcheck
 :configured


### PR DESCRIPTION
This allows subsequent scripts to resolve which NIC has an active DHCP
lease. Useful for passing into a Linux kernel via a kernel parameter.

This only adds a variable, no behavior is changed otherwise.
