### PR TITLE
[hpc] Fix branding

### DIFF
--- a/src/config/hpc/branding.h
+++ b/src/config/hpc/branding.h
@@ -1,4 +1,0 @@
-#undef PRODUCT_NAME
-#define PRODUCT_NAME "HPC Metal iPXE"
-#undef PRODUCT_URI
-#define PRODUCT_URI "https://github.com/Cray-HPE/ipxe"

--- a/src/config/hpc/general.h
+++ b/src/config/hpc/general.h
@@ -1,10 +1,7 @@
-/*
- * Console configuration suitable for use in public cloud
- * environments, or any environment where direct console access is not
- * available.
- *
- */
-
+#undef PRODUCT_NAME
+#define PRODUCT_NAME "HPC Metal iPXE"
+#undef PRODUCT_URI
+#define PRODUCT_URI "https://github.com/Cray-HPE/ipxe"
 
 /* Enable VLAN command: https://ipxe.org/buildcfg/vlan_cmd */
 #define VLAN_CMD


### PR DESCRIPTION
For users of the `hpc` config we want the iPXE URL to point them to where the `hpc` config exists.

The `branding.h` file is not configurable, it never loads a config's `branding.h`. This change moves the branding changes into `general.h` so they're properly loaded.
