### PR TITLE
[hpc] do not try to override branding

### DIFF
--- a/src/config/hpc/general.h
+++ b/src/config/hpc/general.h
@@ -1,8 +1,3 @@
-#undef PRODUCT_NAME
-#define PRODUCT_NAME "HPC Metal iPXE"
-#undef PRODUCT_URI
-#define PRODUCT_URI "https://github.com/Cray-HPE/ipxe"
-
 /* Enable VLAN command: https://ipxe.org/buildcfg/vlan_cmd */
 #define VLAN_CMD
 


### PR DESCRIPTION
The merge from #4 causes a build failure:

```
11:37:43  ./config/branding.h:27:0: error: "PRODUCT_NAME" redefined [-Werror]
11:37:43   #define PRODUCT_NAME ""
11:37:43   
11:37:43  In file included from ./config/general.h:206:0,
11:37:43                   from include/ipxe/acpi.h:20,
11:37:43                   from include/ipxe/sanboot.h:21,
11:37:43                   from usr/autoboot.c:33:
11:37:43  ./config/hpc/general.h:2:0: note: this is the location of the previous definition
11:37:43   #define PRODUCT_NAME "HPC Metal iPXE"
11:37:43   
11:37:43  In file included from usr/autoboot.c:49:0:
11:37:43  ./config/branding.h:29:0: error: "PRODUCT_URI" redefined [-Werror]
11:37:43   #define PRODUCT_URI "https://ipxe.org/"
11:37:43   
11:37:43  In file included from ./config/general.h:206:0,
11:37:43                   from include/ipxe/acpi.h:20,
11:37:43                   from include/ipxe/sanboot.h:21,
11:37:43                   from usr/autoboot.c:33:
11:37:43  ./config/hpc/general.h:4:0: note: this is the location of the previous definition
11:37:43   #define PRODUCT_URI "https://github.com/Cray-HPE/ipxe"
```