### PR TITLE
[hpc] Set DHCP timeouts

### DIFF
--- a/src/config/hpc/general.h
+++ b/src/config/hpc/general.h
@@ -34,13 +34,17 @@ usage: Used for triaging TCP/IP routing and general connectivity.
 */
 #define PING_CMD
 
-// Iterate through unplugged links faster
-#ifdef LINK_WAIT_TIMEOUT
-#undef LINK_WAIT_TIMEOUT
-#define LINK_WAIT_TIMEOUT ( 5 * TICKS_PER_SEC )
+/* DHCP config */
+#ifdef DHCP_DISC_START_TIMEOUT_SEC
+#undef DHCP_DISC_START_TIMEOUT_SEC
 #endif
+#define DHCP_DISC_START_TIMEOUT_SEC	    4
+#ifdef DHCP_DISC_END_TIMEOUT_SEC
+#undef DHCP_DISC_END_TIMEOUT_SEC
+#endif
+#define DHCP_DISC_END_TIMEOUT_SEC	    32
 
-/* No LACP please */
+/* No LACP */
 #ifdef NET_PROTO_LACP
 #undef NET_PROTO_LACP
 #endif


### PR DESCRIPTION
Fixes MTL-1957, adds the DHCP timeouts that facilitate iPXE boots with [intel] x722-10gt interfaces.