### PR TITLE
add arm64 support

### DIFF
--- a/src/config/hpc/hpc.ipxe
+++ b/src/config/hpc/hpc.ipxe
@@ -32,9 +32,6 @@ ifstat
 echo === Loading Menu ... ===============================
 # This should be coded to always point to our LiveCD alias and nothing else.
 # Figure out if client is 64-bit capable
-cpuid --ext 29 && set arch x86_64 || set arch x86
-cpuid --ext 29 && set archb 64 || set archb 32
-cpuid --ext 29 && set archl x86_64 || set archl i386
 colour --basic 0 4
 cpair --background 4 0
 set menu-timeout 2000
@@ -43,6 +40,29 @@ set server-ip ${dhcp-server}
 set script-url http://${dhcp-server}
 # If the hostname is set in the DHCPOFFER use that for a personalized script.
 isset ${hostname} && set script-url ${script-url}/${hostname}/script.ipxe || set script-url ${script-url}/boot/script.ipxe
+
+# Get cpu architecture
+iseq ${buildarch} arm64 && goto arm64 ||
+cpuid --ext 29 && goto x86_64 || goto i386
+
+:arm64
+  set arch arm64
+  set archb 64
+  set archl arm64
+  goto start
+
+:x86_64
+  set arch x86_64
+  set archb 64
+  set archl x86_64
+  goto start
+
+:i386
+  set arch i386
+  set archb 32
+  set archl i386
+  goto start
+
 :start
 menu Metal Pre-Boot :: ${manufacturer} ${product} (${archb}bit)
 item --gap -- ---------------- Boot Choices ----------------

--- a/src/config/hpc/settings.h
+++ b/src/config/hpc/settings.h
@@ -1,4 +1,6 @@
 /* It can often be useful to know the CPU on which a cloud instance is
  * running (e.g. to isolate problems with Azure AMD instances).
  */
+#ifdef IMAGE_FILE_MACHINE_ARM64
 #define CPUID_SETTINGS
+#endif


### PR DESCRIPTION
## Summary and Scope

Add arm support
- src/config/hpc/settings.h -- define CPUID_SETTINGS only when building for x86
- src/config/hpc/hpc.ipxe -- use cpuid to determine architecture only on x86

## Testing

- tested locally using VM's

### Test description:

Built locally for arm64 and x86_64.
Booted kernel / initrd from ipxe in VM's for both architectues.

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

