### PR TITLE
Fix prompt for NIC scan

### DIFF
--- a/src/config/hpc/hpc.ipxe
+++ b/src/config/hpc/hpc.ipxe
@@ -1,7 +1,7 @@
 #!ipxe
 
 set print-nics:int8 0
-:nics
+:nics_scan
 echo === NIC DISCOVERY ==================================
 # Must start at 0; uint does not start at 0.
 set idx:int8 0
@@ -68,7 +68,7 @@ exit 0
 
 :nics
 set print-nics 1
-goto nic_naming
+goto nics_scan
 
 :config
 config


### PR DESCRIPTION
The labels were duplicated, causing the "Print NIC Information" option to actually jump back to the scan section without setting `print-nics=1`. This prevented the prompt from activating, preventing the information from pausing on the screen.
