### PR TITLE
MTL-2104 & CASMCMS-9041 "backport" Update to latest iPXE source

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -706,6 +706,17 @@ privkey_DEPS += $(PRIVKEY_LIST)
 
 CFLAGS_privkey += $(if $(PRIVKEY),-DPRIVATE_KEY="\"$(PRIVKEY_INC)\"")
 
+# Bearer Tokens
+#
+ifdef BEARER_TOKEN
+CFLAGS += $(if $(BEARER_TOKEN),-DHTTP_AUTH_BEARER -DHTTP_AUTH_BEARER_TOKEN="\"$(BEARER_TOKEN)\"")
+endif
+
+# S3
+ifdef S3_HOST
+CFLAGS += -DS3_HOST=\"$(S3_HOST)\"
+endif
+
 # (Single-element) list of named configurations
 #
 CONFIG_LIST := $(BIN)/.config.list
@@ -1063,7 +1074,7 @@ CLEANUP		+= $(BIN)/NIC	# Doesn't match the $(BIN)/*.* pattern
 
 # Analyse a target name (e.g. "bin/dfe538--prism2_pci.rom.tmp") and
 # derive the variables:
-# 
+#
 # TGT_ELEMENTS : the elements of the target (e.g. "dfe538 prism2_pci")
 # TGT_PREFIX   : the prefix type (e.g. "pcirom")
 # TGT_DRIVERS  : the driver for each element (e.g. "rtl8139 prism2_pci")
@@ -1322,7 +1333,7 @@ $(BIN)/%.zbin : $(BIN)/%.bin $(BIN)/%.zinfo $(ZBIN)
 # Rules for each media format.  These are generated and placed in an
 # external Makefile fragment.  We could do this via $(eval ...), but
 # that would require make >= 3.80.
-# 
+#
 # Note that there's an alternative way to generate most .rom images:
 # they can be copied from their 'master' ROM image using cp and
 # reprocessed with makerom to add the PCI IDs and ident string.  The
@@ -1331,10 +1342,10 @@ $(BIN)/%.zbin : $(BIN)/%.bin $(BIN)/%.zinfo $(ZBIN)
 #   $(BIN)/dfe538%rom : $(BIN)/rtl8139%rom
 #	cat $< $@
 #	$(FINALISE_rom)
-# 
+#
 # You can derive the ROM/driver relationships using the variables
 # DRIVER_<rom> and/or ROMS_<driver>.
-# 
+#
 # We don't currently do this, because (a) it would require generating
 # yet more Makefile fragments (since you need a rule for each ROM in
 # ROMS), and (b) the linker is so fast that it probably wouldn't make

--- a/src/config/hpc/general.h
+++ b/src/config/hpc/general.h
@@ -51,6 +51,9 @@ usage: Used for triaging TCP/IP routing and general connectivity.
 #endif
 #define DHCP_DISC_MAX_DEFERRALS		    180
 
+/* Enable Secure Hypertext Transfer Protocol */
+#define	DOWNLOAD_PROTO_HTTPS
+
 /* No LACP */
 #ifdef NET_PROTO_LACP
 #undef NET_PROTO_LACP

--- a/src/config/hpc/general.h
+++ b/src/config/hpc/general.h
@@ -46,6 +46,10 @@ usage: Used for triaging TCP/IP routing and general connectivity.
 #undef DHCP_DISC_END_TIMEOUT_SEC
 #endif
 #define DHCP_DISC_END_TIMEOUT_SEC	    32
+#ifdef DHCP_DISC_MAX_DEFERRALS
+#undef DHCP_DISC_MAX_DEFERRALS
+#endif
+#define DHCP_DISC_MAX_DEFERRALS		    180
 
 /* No LACP */
 #ifdef NET_PROTO_LACP

--- a/src/config/hpc/general.h
+++ b/src/config/hpc/general.h
@@ -1,3 +1,6 @@
+/* Enable CERT command: https://ipxe.org/buildcfg/cert_cmd */
+#define CERT_CMD
+
 /* Enable VLAN command: https://ipxe.org/buildcfg/vlan_cmd */
 #define VLAN_CMD
 

--- a/src/net/tcp/httpcore.c
+++ b/src/net/tcp/httpcore.c
@@ -124,6 +124,10 @@ static struct http_state http_headers;
 static struct http_state http_trailers;
 static struct http_transfer_encoding http_transfer_identity;
 
+#ifdef HTTP_AUTH_BEARER
+static int http_redirect_request = 0;
+#endif
+
 /******************************************************************************
  *
  * Methods
@@ -701,6 +705,10 @@ static int http_redirect ( struct http_transaction *http,
 	int rc;
 
 	DBGC2 ( http, "HTTP %p redirecting to \"%s\"\n", http, location );
+#ifdef HTTP_AUTH_BEARER
+	http_redirect_request=1;
+#endif
+
 
 	/* Parse location URI */
 	location_uri = parse_uri ( location );
@@ -840,6 +848,14 @@ static int http_format_headers ( struct http_transaction *http, char *buf,
 	int value_len;
 	int rc;
 
+	/* Host and path debug info */
+	DBGC2 ( http, "HTTP http_format_headers %p TX request host: %s\n", http, http->uri->host );
+	DBGC2 ( http, "HTTP http_format_headers %p TX request path: %s\n", http, http->uri->path );
+
+#ifdef S3_HOST
+	DBGC2 ( http, "HTTP http_format_headers %p TX S3_HOST: %s\n", http, S3_HOST );
+#endif
+
 	/* Construct request line */
 	used = ssnprintf ( buf, len, "%s %s HTTP/1.1",
 			   http->request.method->name, http->request.uri );
@@ -860,6 +876,19 @@ static int http_format_headers ( struct http_transaction *http, char *buf,
 		/* Skip zero-length headers */
 		if ( ! value_len )
 			continue;
+
+#ifdef HTTP_AUTH_BEARER
+#ifdef S3_HOST
+		/* Skip Authorization header on a redirect or if going directly to S3 */
+		if ( http_redirect_request == 1 || strcmp( S3_HOST, http->uri->host ) == 0 ) {
+			if ( ! strcmp("Authorization",header->name) ) {
+				DBGC2 ( http, "HTTP %p TX not including header: %s\n", http, header->name );
+				continue;
+			}
+		}
+#endif
+#endif
+
 
 		/* Construct header */
 		line = ( buf + used );
@@ -1102,6 +1131,13 @@ static int http_tx_request ( struct http_transaction *http ) {
 	assert ( check_len == len );
 	memcpy ( iob_put ( iobuf, http->request.content.len ),
 		 http->request.content.data, http->request.content.len );
+
+#ifdef HTTP_AUTH_BEARER
+	/* Were done processing headers so reset the flag */
+	if ( http_redirect_request == 1 ) {
+		http_redirect_request=0;
+	}
+#endif
 
 	/* Deliver request */
 	if ( ( rc = xfer_deliver_iob ( &http->conn,
@@ -1989,6 +2025,29 @@ int http_open_uri ( struct interface *xfer, struct uri *uri ) {
  err_alloc:
 	return rc;
 }
+
+#ifdef HTTP_AUTH_BEARER
+/**
+ * Construct HTTP "Authorization: Bearer token" header
+ *
+ * @v http		HTTP transaction
+ * @v buf		Buffer
+ * @v len		Length of buffer
+ * @ret len		Length of header value, or negative error
+ */
+static int http_format_authorization_bearer ( struct http_transaction *http __unused,
+				    char *buf, size_t len ) {
+
+	/* Construct bearer token */
+	return snprintf ( buf, len, "Bearer %s",  HTTP_AUTH_BEARER_TOKEN );
+}
+
+/** HTTP "Authorization: Bearer" header */
+struct http_request_header http_request_authorization_bearer __http_request_header = {
+	.name = "Authorization",
+	.format = http_format_authorization_bearer,
+};
+#endif // HTTP_AUTH_BEARER
 
 /* Drag in HTTP extensions */
 REQUIRING_SYMBOL ( http_open );


### PR DESCRIPTION
Factors in missing changes from the internal iPXE source that never landed in our fork.
- HTTPS Bearer Token Auth Header fixes
- EFI Root search for ACPI systems
- Enable HTTPS for the "hpc" config
- Custom `DHCP_DISC_MAX_DEFERRALS` for the "hpc" config