### PR TITLE
MTL-2435 Restore boot chain in HPC embedded script

### DIFF
--- a/src/config/hpc/README.md
+++ b/src/config/hpc/README.md
@@ -1,3 +1,46 @@
-# High-Performance Computing Metal
+# High-Performance Computing iPXE
 
-These files facilitate bootstrapping server deployments for high-performance computing on bare-metal.
+This iPXE configuration is tuned for booting large quantities of new hardware in
+Hewlett-Packard Enterprise' High-Performance Computer and Artificial Intelligence division.
+
+## Embedded Script
+
+The `hpc.ipxe` script is an optional script to embed.
+
+Functions:
+- Prints out NIC information
+  - PCI Signatures
+  - MAC Addresses
+  - Current link states
+- DHCPs from the iPXE ROM
+    - Picks up option-175 if set ([ref][^1])
+- Provides a menu:
+  - Shows resolved boot server
+  - Allows a user to specify a different chain
+  - Re-print NIC information
+  - Reboot the server
+  - Exit to the BIOS menu
+  - View iPXE settings
+  - Access an iPXE shell
+  
+#### Booting
+
+The embedded script will try three boot method before giving up.
+
+#### iPXE option-175
+
+If [`option-175`][^1] is provided to iPXE when it DHCPs again (after PXE has DHCPed and loaded the iPXE ROM), the embedded script will look for the script name contained in `option-175` on the bootserver.
+
+If `option-175` is not set, then the embedded script will fallback to searching for a file named `script.ipxe`.
+
+Regardless of whether `option-175`is set, the embedded script looks in the following locations for the target chain script:
+
+> Note: If `crosscert` is detected then the embedded script will use HTTPS, otherwise it will use HTTP.
+
+| Order        | URL                                                     | Example                                                            |
+|--------------|---------------------------------------------------------|--------------------------------------------------------------------|
+| 1            | `https?://${next-server}/${hostname}/${script-name}`    | `http://10.1.1.1/myserver/boot.php`                                | 
+| 2            | `https?://${next-server}/${ipv4:uint32}/${script-name}` | `http://10.1.1.1/0xa10015/boot.php` if the leased IP was 10.1.0.21 |
+| 3 (fallback) | `https?://${next-server}/${script-name}`                | `http://10.1.1.1/boot.php`                                         |
+
+[^1]: https://ipxe.org/appnote/premature#pxe_chainloading

--- a/src/config/hpc/hpc.ipxe
+++ b/src/config/hpc/hpc.ipxe
@@ -104,6 +104,10 @@ goto nics_scan
 :change
 read script-url
 goto boot
+
+:reboot
+reboot
+
 :config
 config
 goto start

--- a/src/config/hpc/hpc.ipxe
+++ b/src/config/hpc/hpc.ipxe
@@ -1,5 +1,9 @@
 #!ipxe
 
+set default-script script.ipxe
+
+set original-filename ${filename}
+
 set print-nics:int8 0
 :nics_scan
 echo === NIC DISCOVERY ==================================
@@ -9,7 +13,7 @@ set idx:int8 0
   echo net${idx} MAC ${net${idx}/mac} PCI.DeviceID ${pci/${net${idx}/busloc}.2.2} PCI.VendorID ${pci/${net${idx}/busloc}.0.2}
   inc idx && goto check
 :checked
-iseq ${print-nics} 1 && prompt Press any key to continue && goto menu || goto menu
+iseq ${print-nics} 1 && prompt Press any key to continue && goto menu ||
 
 echo === LINK ===========================================
 set vidx:int8 0
@@ -17,6 +21,25 @@ set vidx:int8 0
   ifopen net${vidx} && ifstat net${vidx} || echo Failed to open net${vidx}
   inc vidx && goto linkcheck
 :opened
+
+echo === DHCP ===========================================
+# Shut down all interfaces and open them as needed. Sternly prevents iPXE from
+# making bad decisions selecting which interface traffic egresses.
+ifclose
+set vidx:int8 0
+:dhcpcheck isset ${net${vidx}/mac} || goto configured
+  ifopen net${vidx} || echo Failed to open net${vidx}
+  set boot-nic net${vidx} # constantly set this, once DHCP works this'll refer to the right NIC.
+  ifconf -c dhcp --timeout 20000 net${vidx} && goto configured || ifclose net${vidx}
+  inc vidx && goto dhcpcheck
+:configured
+# ipxe option 175 is handed out by an isc-dhcp server when iPXE DHCPs, it will not be given out to normal PXEClient or HTTPClient requests.
+# If the current filename from our DHCP matches the original filename, then we were not handed out ipxe option 175.
+iseq ${original-filename} ${filename} && echo iPXE option 175 was not detected, falling back to filename=${default-script} || echo iPXE option 175 detected: ${filename}
+iseq ${original-filename} ${filename} && set script-name ${default-script} || set script-name ${filename}
+echo Dumping interface status:
+isset ${net${vidx}/ip} && show net${vidx}/ip || echo No interfaces were configured
+ifstat
 
 :menu
 echo === Loading Menu ... ===============================
@@ -49,9 +72,16 @@ cpuid --ext 29 && goto x86_64 || goto i386
   goto start
 
 :start
+set try-ip:int8 1
+set try-hostname:int8 1
+set last-try:int8 0
+set server-ip ${next-server}
+
 menu Metal Pre-Boot :: ${manufacturer} ${product} (${archb}bit)
-item --gap -- ---------------- Choices       ----------------
-item --key n nics     Print (N)IC information
+item --gap -- ---------------- Boot Choices ----------------
+item --key d default        (D)efault next (${server-ip})
+item --key c change         (C)hange next to ...
+item --key n nics           Print (N)IC information
 item --key r reboot         (R)eboot
 item --key e bios           (E)xit to BIOS Menu
 item
@@ -59,7 +89,8 @@ item --gap -- ---------------- Advanced configuration ----------------
 item --key i config   Configure / View (i)PXE settings
 item --key s shell    Enter iPXE (s)hell
 item
-choose --default default target || goto cancel ||
+choose --default default --timeout ${menu-timeout} target || goto cancel ||
+set menu-timeout:int8 0
 goto ${target}
 
 :bios
@@ -70,6 +101,9 @@ exit 0
 set print-nics 1
 goto nics_scan
 
+:change
+read script-url
+goto boot
 :config
 config
 goto start
@@ -83,3 +117,32 @@ goto start
 :cancel
 echo Menu cancelled, dropping to iPXE shell ...
 goto shell
+
+:default
+iseq ${last-try} 1 && goto failed ||
+
+# Keep it secret, keep it safe - stash the next-server in case the lease times out or the NIC resets.
+isset ${crosscert} && set script-url https://${server-ip} || set script-url http://${server-ip}
+
+# Precedence
+# 1. Download a script based on hostname from the DHCP lease.
+# 2. Download a script based on the IP leased from DHCP (as unsigned integer: 10.1.0.21 == 0xa10015).
+# 3. Download a generic script from the root of the next-server address.
+
+iseq ${try-hostname} 1 && set script-url ${script-url}/${hostname}/${script-name} && set try-hostname 0 && goto boot ||
+
+iseq ${try-ip} 1 && set script-url ${script-url}/${${boot-nic}/ip:uint32}/${script-name} && set try-ip 0 && goto boot ||
+
+iseq ${try-ip} 0 && iseq ${try-hostname} 0 && set script-url ${script-url}/${script-name} && set last-try 1 && goto boot ||
+
+# go to menu; reset the timeout and retry all the end points. Allows for a user to interrupt and poke around.
+goto menu
+
+:boot
+echo querying ${script-url}
+chain --autofree --replace ${script-url} || goto default
+
+:failed
+echo Exiting iPXE; depending on vendor this will drop to the next PXE interface or to BIOS.
+echo If BIOS appears next, select either of the DISK entries.
+exit 1


### PR DESCRIPTION
This updates a few items:
- New `README.md` for `src/config/hpc/`
- Adds iPXE DHCP loop to `src/config/hpc/hpc.ipxe`
- Adds new menu options for chaining in `src/config/hpc/hpc.ipxe`
- Fixes the "Reboot" menu option in `src/config/hpc/hpc.ipxe`


#### Examples

##### With `option-175`
```
# dnsmasq.conf
dhcp-match=set:ipxe,175
dhcp-boot=tag:ipxe,script.ipxe
```

```
>>Start PXE over IPv4.
  Station IP address is 10.1.0.21

  Server IP address is 10.1.1.1
  NBP filename is ipxe.x86_64.efi
  NBP filesize is 765952 Bytes
 Downloading NBP file...

  NBP file downloaded successfully.
iPXE initialising devices...
autoexec.ipxe... Not found (https://ipxe.org/2d12618e)



iPXE 1.0.0+ (MTL-2435-restore-boot-chain) -- Open Source Network Boot Firmware -- https://ipxe.org
Features: DNS HTTP HTTPS iSCSI TFTP VLAN SRP AoE EFI Menu
=== NIC DISCOVERY ==================================
net0 MAC a4:bf:01:6f:6a:fe PCI.DeviceID 37d2 PCI.VendorID 8086
net1 MAC a4:bf:01:6f:6a:ff PCI.DeviceID 37d2 PCI.VendorID 8086
net2 MAC 5c:ed:8c:86:7f:42 PCI.DeviceID 8070 PCI.VendorID 1077
net3 MAC 5c:ed:8c:86:7f:43 PCI.DeviceID 8070 PCI.VendorID 1077
net4 MAC 5c:ed:8c:86:66:04 PCI.DeviceID 8070 PCI.VendorID 1077
net5 MAC 5c:ed:8c:86:66:05 PCI.DeviceID 8070 PCI.VendorID 1077
=== LINK ===========================================
net0: a4:bf:01:6f:6a:fe using x722-10gt on 0000:3d:00.0 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net1: a4:bf:01:6f:6a:ff using x722-10gt on 0000:3d:00.1 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net2: 5c:ed:8c:86:7f:42 using NII on NII-0001:81:00.0 (Ethernet) [open]
  [Link:down, TX:0 TXE:1 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
  [TXE: 1 x "Network unreachable (https://ipxe.org/28086090)"]
net3: 5c:ed:8c:86:7f:43 using NII on NII-0001:81:00.1 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net4: 5c:ed:8c:86:66:04 using NII on NII-0001:da:00.0 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net5: 5c:ed:8c:86:66:05 using NII on NII-0001:da:00.1 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
=== DHCP ===========================================
Waiting for link-up on net0................. Down (https://ipxe.org/38086193)
Waiting for link-up on net1................. Down (https://ipxe.org/38086193)
Configuring [dhcp] (net2 5c:ed:8c:86:7f:42)...... ok
iPXE option 175 detected: script.ipxe
Dumping interface status:
net2.dhcp/ip:ipv4 = 10.1.0.21
net0: a4:bf:01:6f:6a:fe using x722-10gt on 0000:3d:00.0 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net1: a4:bf:01:6f:6a:ff using x722-10gt on 0000:3d:00.1 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net2: 5c:ed:8c:86:7f:42 using NII on NII-0001:81:00.0 (Ethernet) [open]
  [Link:up, TX:9 TXE:5 RX:47 RXE:19]
  [TXE: 1 x "Network unreachable (https://ipxe.org/28086090)"]
  [TXE: 4 x "Error 0x2a086089 (https://ipxe.org/2a086089)"]
  [RXE: 15 x "Error 0x42306095 (https://ipxe.org/42306095)"]
  [RXE: 3 x "Error 0x440e6083 (https://ipxe.org/440e6083)"]
  [RXE: 1 x "Operation not supported (https://ipxe.org/3c086083)"]
net3: 5c:ed:8c:86:7f:43 using NII on NII-0001:81:00.1 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net4: 5c:ed:8c:86:66:04 using NII on NII-0001:da:00.0 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net5: 5c:ed:8c:86:66:05 using NII on NII-0001:da:00.1 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
=== Loading Menu ... ===============================

              Metal Pre-Boot :: Intel Corporation S2600WFT (64bit)

   ---------------- Boot Choices ----------------
   (D)efault next (10.1.1.1)
   (C)hange next to ...
   Print (N)IC information
   (R)eboot
   (E)xit to BIOS Menu

   ---------------- Advanced configuration ----------------
   Configure / View (i)PXE settings
   Enter iPXE (s)hell
querying http://10.1.1.1/ncn-h003/script.ipxe
http://10.1.1.1/ncn-h003/script.ipxe... Operation not permitted (https://ipxe.org/410c618f)
querying http://10.1.1.1/0xa010015/script.ipxe
http://10.1.1.1/0xa010015/script.ipxe... Operation not permitted (https://ipxe.org/410c618f)
querying http://10.1.1.1/script.ipxe
http://10.1.1.1/script.ipxe... Not found (https://ipxe.org/2d0c618e)
Exiting iPXE; depending on vendor this will drop to the next PXE interface or to BIOS.
If BIOS appears next, select either of the DISK entries.
```

##### without option-175

```
>>Start PXE over IPv4.
  Station IP address is 10.1.0.21

  Server IP address is 10.1.1.1
  NBP filename is ipxe.x86_64.efi
  NBP filesize is 765952 Bytes
 Downloading NBP file...

  NBP file downloaded successfully.
iPXE initialising devices...
autoexec.ipxe... Not found (https://ipxe.org/2d12618e)



iPXE 1.0.0+ (MTL-2435-restore-boot-chain) -- Open Source Network Boot Firmware -- https://ipxe.org
Features: DNS HTTP HTTPS iSCSI TFTP VLAN SRP AoE EFI Menu
=== NIC DISCOVERY ==================================
net0 MAC a4:bf:01:6f:6a:fe PCI.DeviceID 37d2 PCI.VendorID 8086
net1 MAC a4:bf:01:6f:6a:ff PCI.DeviceID 37d2 PCI.VendorID 8086
net2 MAC 5c:ed:8c:86:7f:42 PCI.DeviceID 8070 PCI.VendorID 1077
net3 MAC 5c:ed:8c:86:7f:43 PCI.DeviceID 8070 PCI.VendorID 1077
net4 MAC 5c:ed:8c:86:66:04 PCI.DeviceID 8070 PCI.VendorID 1077
net5 MAC 5c:ed:8c:86:66:05 PCI.DeviceID 8070 PCI.VendorID 1077
=== LINK ===========================================
net0: a4:bf:01:6f:6a:fe using x722-10gt on 0000:3d:00.0 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net1: a4:bf:01:6f:6a:ff using x722-10gt on 0000:3d:00.1 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net2: 5c:ed:8c:86:7f:42 using NII on NII-0001:81:00.0 (Ethernet) [open]
  [Link:down, TX:0 TXE:1 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
  [TXE: 1 x "Network unreachable (https://ipxe.org/28086090)"]
net3: 5c:ed:8c:86:7f:43 using NII on NII-0001:81:00.1 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net4: 5c:ed:8c:86:66:04 using NII on NII-0001:da:00.0 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net5: 5c:ed:8c:86:66:05 using NII on NII-0001:da:00.1 (Ethernet) [open]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
=== DHCP ===========================================
Waiting for link-up on net0................. Down (https://ipxe.org/38086193)
Waiting for link-up on net1................. Down (https://ipxe.org/38086193)
Configuring [dhcp] (net2 5c:ed:8c:86:7f:42)...... ok
iPXE option 175 was not detected, falling back to filename=script.ipxe
Dumping interface status:
net2.dhcp/ip:ipv4 = 10.1.0.21
net0: a4:bf:01:6f:6a:fe using x722-10gt on 0000:3d:00.0 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net1: a4:bf:01:6f:6a:ff using x722-10gt on 0000:3d:00.1 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Down (https://ipxe.org/38086193)]
net2: 5c:ed:8c:86:7f:42 using NII on NII-0001:81:00.0 (Ethernet) [open]
  [Link:up, TX:9 TXE:5 RX:62 RXE:32]
  [TXE: 1 x "Network unreachable (https://ipxe.org/28086090)"]
  [TXE: 4 x "Error 0x2a086089 (https://ipxe.org/2a086089)"]
  [RXE: 4 x "Error 0x440e6083 (https://ipxe.org/440e6083)"]
  [RXE: 26 x "Error 0x42306095 (https://ipxe.org/42306095)"]
  [RXE: 2 x "Operation not supported (https://ipxe.org/3c086083)"]
net3: 5c:ed:8c:86:7f:43 using NII on NII-0001:81:00.1 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net4: 5c:ed:8c:86:66:04 using NII on NII-0001:da:00.0 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
net5: 5c:ed:8c:86:66:05 using NII on NII-0001:da:00.1 (Ethernet) [closed]
  [Link:down, TX:0 TXE:0 RX:0 RXE:0]
  [Link status: Unknown (https://ipxe.org/1a086194)]
=== Loading Menu ... ===============================

              Metal Pre-Boot :: Intel Corporation S2600WFT (64bit)

   ---------------- Boot Choices ----------------
   (D)efault next (10.1.1.1)
   (C)hange next to ...
   Print (N)IC information
   (R)eboot
   (E)xit to BIOS Menu

   ---------------- Advanced configuration ----------------
   Configure / View (i)PXE settings
   Enter iPXE (s)hell
querying http://10.1.1.1/ncn-h003/script.ipxe
http://10.1.1.1/ncn-h003/script.ipxe... Operation not permitted (https://ipxe.org/410c618f)
querying http://10.1.1.1/0xa010015/script.ipxe
http://10.1.1.1/0xa010015/script.ipxe... Operation not permitted (https://ipxe.org/410c618f)
querying http://10.1.1.1/script.ipxe
http://10.1.1.1/script.ipxe... Not found (https://ipxe.org/2d0c618e)
Exiting iPXE; depending on vendor this will drop to the next PXE interface or to BIOS.
If BIOS appears next, select either of the DISK entries.
```